### PR TITLE
feat: add dark mode toggle

### DIFF
--- a/app/components/DarkModeToggle.tsx
+++ b/app/components/DarkModeToggle.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { useTheme } from './ThemeProvider';
+
+export default function DarkModeToggle() {
+  const { theme, toggleTheme } = useTheme();
+  const isDark = theme === 'dark';
+
+  return (
+    <button
+      onClick={toggleTheme}
+      role="switch"
+      aria-checked={isDark}
+      aria-label="Toggle dark mode"
+      className="relative inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-foreground focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+      style={{ backgroundColor: isDark ? '#6366f1' : 'var(--border)' }}
+    >
+      <span
+        aria-hidden="true"
+        className="pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow-lg ring-0 transition-transform"
+        style={{ transform: isDark ? 'translateX(1.25rem)' : 'translateX(0)' }}
+      />
+    </button>
+  );
+}

--- a/app/components/ThemeProvider.tsx
+++ b/app/components/ThemeProvider.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import { createContext, useContext, useEffect, useState } from 'react';
+
+type Theme = 'light' | 'dark';
+
+const ThemeContext = createContext<{
+  theme: Theme;
+  toggleTheme: () => void;
+}>({ theme: 'light', toggleTheme: () => {} });
+
+export function useTheme() {
+  return useContext(ThemeContext);
+}
+
+export default function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const [theme, setTheme] = useState<Theme>('light');
+
+  useEffect(() => {
+    const stored = localStorage.getItem('theme') as Theme | null;
+    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    const initial = stored ?? (prefersDark ? 'dark' : 'light');
+    setTheme(initial);
+    document.documentElement.classList.toggle('dark', initial === 'dark');
+  }, []);
+
+  const toggleTheme = () => {
+    const next = theme === 'light' ? 'dark' : 'light';
+    setTheme(next);
+    localStorage.setItem('theme', next);
+    document.documentElement.classList.toggle('dark', next === 'dark');
+  };
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,22 +1,31 @@
 @import "tailwindcss";
 
+@custom-variant dark (&:where(.dark, .dark *));
+
 :root {
   --background: #ffffff;
   --foreground: #171717;
+  --surface: #f9fafb;
+  --border: #e5e7eb;
+  --muted: #6b7280;
+}
+
+.dark {
+  --background: #0a0a0a;
+  --foreground: #ededed;
+  --surface: #1a1a1a;
+  --border: #2e2e2e;
+  --muted: #9ca3af;
 }
 
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
+  --color-surface: var(--surface);
+  --color-border: var(--border);
+  --color-muted: var(--muted);
   --font-sans: var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
-}
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
-  }
 }
 
 body {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import ThemeProvider from "./components/ThemeProvider";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -27,7 +28,9 @@ export default function RootLayout({
       lang="en"
       className={`${geistSans.variable} ${geistMono.variable} h-full antialiased`}
     >
-      <body className="min-h-full flex flex-col">{children}</body>
+      <body className="min-h-full flex flex-col bg-background text-foreground">
+        <ThemeProvider>{children}</ThemeProvider>
+      </body>
     </html>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,8 +1,13 @@
+import DarkModeToggle from "./components/DarkModeToggle";
+
 export default function Home() {
   return (
-    <main className="min-h-screen bg-white p-8">
-      <h1 className="text-3xl font-bold text-gray-900 mb-2">Todo List</h1>
-      <p className="text-gray-500">No features implemented yet.</p>
+    <main className="min-h-screen bg-background p-8">
+      <div className="flex items-center justify-between mb-6">
+        <h1 className="text-3xl font-bold text-foreground">Todo List</h1>
+        <DarkModeToggle />
+      </div>
+      <p className="text-muted">No features implemented yet.</p>
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- Adds a toggle switch in the top-right of the page to switch between light and dark themes
- Uses CSS custom properties (`--background`, `--foreground`, `--surface`, `--border`, `--muted`) driven by a `.dark` class on `<html>`
- Persists user preference in `localStorage`; falls back to `prefers-color-scheme` on first visit
- `ThemeProvider` client component manages theme state; `DarkModeToggle` renders the switch

Closes #8

## Test plan
- [ ] Toggle the switch — page background and text flip between light and dark
- [ ] Refresh the page — chosen theme persists
- [ ] Open in a browser with `prefers-color-scheme: dark` with no stored preference — starts in dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)