### PR TITLE
feat: add due dates to todos

### DIFF
--- a/app/components/DueDateBadge.tsx
+++ b/app/components/DueDateBadge.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+interface DueDateBadgeProps {
+  dueDate: string;
+  completed: boolean;
+}
+
+function getDueDateStatus(dueDate: string, completed: boolean) {
+  if (completed) return { label: formatDate(dueDate), className: "text-foreground/40 line-through" };
+
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  const due = new Date(dueDate + "T00:00:00");
+  const diffDays = Math.round((due.getTime() - today.getTime()) / (1000 * 60 * 60 * 24));
+
+  if (diffDays < 0) {
+    return { label: `Overdue · ${formatDate(dueDate)}`, className: "text-red-600 dark:text-red-400 font-medium" };
+  }
+  if (diffDays === 0) {
+    return { label: `Due today`, className: "text-amber-600 dark:text-amber-400 font-medium" };
+  }
+  if (diffDays <= 3) {
+    return { label: `Due in ${diffDays}d · ${formatDate(dueDate)}`, className: "text-yellow-600 dark:text-yellow-400" };
+  }
+  return { label: formatDate(dueDate), className: "text-foreground/50" };
+}
+
+function formatDate(dateStr: string) {
+  const date = new Date(dateStr + "T00:00:00");
+  return date.toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
+}
+
+export default function DueDateBadge({ dueDate, completed }: DueDateBadgeProps) {
+  const { label, className } = getDueDateStatus(dueDate, completed);
+  return (
+    <span className={`text-xs ${className}`}>
+      {label}
+    </span>
+  );
+}

--- a/app/components/TodoApp.tsx
+++ b/app/components/TodoApp.tsx
@@ -1,0 +1,163 @@
+"use client";
+
+import { useState, useEffect, useRef } from "react";
+import { Todo } from "@/app/types/todo";
+import TodoItem from "./TodoItem";
+
+const STORAGE_KEY = "todos";
+
+function loadTodos(): Todo[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    return raw ? JSON.parse(raw) : [];
+  } catch {
+    return [];
+  }
+}
+
+function saveTodos(todos: Todo[]) {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(todos));
+}
+
+export default function TodoApp() {
+  const [todos, setTodos] = useState<Todo[]>([]);
+  const [inputText, setInputText] = useState("");
+  const [inputDueDate, setInputDueDate] = useState("");
+  const [filter, setFilter] = useState<"all" | "active" | "completed">("all");
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    setTodos(loadTodos());
+  }, []);
+
+  function updateTodos(next: Todo[]) {
+    setTodos(next);
+    saveTodos(next);
+  }
+
+  function addTodo(e: React.FormEvent) {
+    e.preventDefault();
+    const text = inputText.trim();
+    if (!text) return;
+    const todo: Todo = {
+      id: crypto.randomUUID(),
+      text,
+      completed: false,
+      dueDate: inputDueDate || undefined,
+      createdAt: new Date().toISOString(),
+    };
+    updateTodos([todo, ...todos]);
+    setInputText("");
+    setInputDueDate("");
+    inputRef.current?.focus();
+  }
+
+  function toggleTodo(id: string) {
+    updateTodos(todos.map((t) => (t.id === id ? { ...t, completed: !t.completed } : t)));
+  }
+
+  function deleteTodo(id: string) {
+    updateTodos(todos.filter((t) => t.id !== id));
+  }
+
+  function updateDueDate(id: string, dueDate: string | undefined) {
+    updateTodos(todos.map((t) => (t.id === id ? { ...t, dueDate } : t)));
+  }
+
+  const filtered = todos.filter((t) => {
+    if (filter === "active") return !t.completed;
+    if (filter === "completed") return t.completed;
+    return true;
+  });
+
+  const activeCount = todos.filter((t) => !t.completed).length;
+
+  return (
+    <div className="max-w-xl mx-auto py-12 px-4">
+      <h1 className="text-3xl font-bold text-foreground mb-8">Todo List</h1>
+
+      {/* Add todo form */}
+      <form onSubmit={addTodo} className="mb-6">
+        <div className="flex flex-col gap-2">
+          <div className="flex gap-2">
+            <input
+              ref={inputRef}
+              type="text"
+              value={inputText}
+              onChange={(e) => setInputText(e.target.value)}
+              placeholder="What needs to be done?"
+              className="flex-1 px-4 py-2.5 rounded-lg border border-foreground/20 bg-background text-foreground placeholder:text-foreground/40 text-sm focus:outline-none focus:ring-2 focus:ring-foreground/20 focus:border-foreground/40 transition-colors"
+            />
+            <button
+              type="submit"
+              disabled={!inputText.trim()}
+              className="px-4 py-2.5 rounded-lg bg-foreground text-background text-sm font-medium disabled:opacity-30 hover:opacity-80 transition-opacity cursor-pointer disabled:cursor-default"
+            >
+              Add
+            </button>
+          </div>
+          <div className="flex items-center gap-2">
+            <label className="text-xs text-foreground/50">Due date:</label>
+            <input
+              type="date"
+              value={inputDueDate}
+              onChange={(e) => setInputDueDate(e.target.value)}
+              className="text-xs px-2 py-1 rounded border border-foreground/20 bg-background text-foreground focus:outline-none focus:ring-1 focus:ring-foreground/20 transition-colors"
+            />
+            {inputDueDate && (
+              <button
+                type="button"
+                onClick={() => setInputDueDate("")}
+                className="text-xs text-foreground/30 hover:text-foreground/60 transition-colors"
+              >
+                Clear
+              </button>
+            )}
+          </div>
+        </div>
+      </form>
+
+      {/* Filter tabs */}
+      {todos.length > 0 && (
+        <div className="flex gap-1 mb-4">
+          {(["all", "active", "completed"] as const).map((f) => (
+            <button
+              key={f}
+              onClick={() => setFilter(f)}
+              className={`px-3 py-1 rounded text-xs capitalize transition-colors cursor-pointer ${
+                filter === f
+                  ? "bg-foreground text-background"
+                  : "text-foreground/50 hover:text-foreground"
+              }`}
+            >
+              {f}
+            </button>
+          ))}
+          <span className="ml-auto text-xs text-foreground/40 self-center">
+            {activeCount} item{activeCount !== 1 ? "s" : ""} left
+          </span>
+        </div>
+      )}
+
+      {/* Todo list */}
+      {filtered.length > 0 ? (
+        <ul className="rounded-xl border border-foreground/10 bg-background px-4 divide-y-0">
+          {filtered.map((todo) => (
+            <TodoItem
+              key={todo.id}
+              todo={todo}
+              onToggle={toggleTodo}
+              onDelete={deleteTodo}
+              onUpdateDueDate={updateDueDate}
+            />
+          ))}
+        </ul>
+      ) : (
+        <p className="text-sm text-foreground/40 text-center py-8">
+          {filter === "all" ? "No todos yet. Add one above!" : `No ${filter} todos.`}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/app/components/TodoApp.tsx
+++ b/app/components/TodoApp.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useState, useEffect, useRef } from "react";
-import { Todo } from "@/app/types/todo";
+import { useState, useRef } from "react";
+import type { Todo } from "@/app/types/todo";
 import TodoItem from "./TodoItem";
 
 const STORAGE_KEY = "todos";
@@ -21,15 +21,11 @@ function saveTodos(todos: Todo[]) {
 }
 
 export default function TodoApp() {
-  const [todos, setTodos] = useState<Todo[]>([]);
+  const [todos, setTodos] = useState<Todo[]>(loadTodos);
   const [inputText, setInputText] = useState("");
   const [inputDueDate, setInputDueDate] = useState("");
   const [filter, setFilter] = useState<"all" | "active" | "completed">("all");
   const inputRef = useRef<HTMLInputElement>(null);
-
-  useEffect(() => {
-    setTodos(loadTodos());
-  }, []);
 
   function updateTodos(next: Todo[]) {
     setTodos(next);

--- a/app/components/TodoItem.tsx
+++ b/app/components/TodoItem.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { Todo } from "@/app/types/todo";
+import DueDateBadge from "./DueDateBadge";
+
+interface TodoItemProps {
+  todo: Todo;
+  onToggle: (id: string) => void;
+  onDelete: (id: string) => void;
+  onUpdateDueDate: (id: string, dueDate: string | undefined) => void;
+}
+
+export default function TodoItem({ todo, onToggle, onDelete, onUpdateDueDate }: TodoItemProps) {
+  return (
+    <li className="flex items-start gap-3 py-3 border-b border-foreground/10 last:border-0 group">
+      <button
+        onClick={() => onToggle(todo.id)}
+        className={`mt-0.5 flex-shrink-0 w-5 h-5 rounded border-2 transition-colors cursor-pointer ${
+          todo.completed
+            ? "bg-foreground border-foreground"
+            : "border-foreground/30 hover:border-foreground/60"
+        }`}
+        aria-label={todo.completed ? "Mark incomplete" : "Mark complete"}
+      >
+        {todo.completed && (
+          <svg viewBox="0 0 12 12" fill="none" className="w-full h-full p-0.5">
+            <path d="M2 6l3 3 5-5" stroke="white" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+          </svg>
+        )}
+      </button>
+
+      <div className="flex-1 min-w-0">
+        <p className={`text-sm leading-snug ${todo.completed ? "line-through text-foreground/40" : "text-foreground"}`}>
+          {todo.text}
+        </p>
+        <div className="flex items-center gap-2 mt-1 flex-wrap">
+          {todo.dueDate && <DueDateBadge dueDate={todo.dueDate} completed={todo.completed} />}
+          <label className="flex items-center gap-1 cursor-pointer">
+            <span className="text-xs text-foreground/40 hover:text-foreground/60 transition-colors">
+              {todo.dueDate ? "Change date" : "Add due date"}
+            </span>
+            <input
+              type="date"
+              value={todo.dueDate ?? ""}
+              onChange={(e) => onUpdateDueDate(todo.id, e.target.value || undefined)}
+              className="absolute opacity-0 w-0 h-0"
+              aria-label="Set due date"
+            />
+          </label>
+          {todo.dueDate && (
+            <button
+              onClick={() => onUpdateDueDate(todo.id, undefined)}
+              className="text-xs text-foreground/30 hover:text-red-500 transition-colors"
+              aria-label="Remove due date"
+            >
+              ✕
+            </button>
+          )}
+        </div>
+      </div>
+
+      <button
+        onClick={() => onDelete(todo.id)}
+        className="flex-shrink-0 opacity-0 group-hover:opacity-100 text-foreground/30 hover:text-red-500 transition-all text-sm cursor-pointer"
+        aria-label="Delete todo"
+      >
+        ✕
+      </button>
+    </li>
+  );
+}

--- a/app/components/TodoItem.tsx
+++ b/app/components/TodoItem.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Todo } from "@/app/types/todo";
+import type { Todo } from "@/app/types/todo";
 import DueDateBadge from "./DueDateBadge";
 
 interface TodoItemProps {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,8 +1,9 @@
+import TodoApp from "@/app/components/TodoApp";
+
 export default function Home() {
   return (
-    <main className="min-h-screen bg-white p-8">
-      <h1 className="text-3xl font-bold text-gray-900 mb-2">Todo List</h1>
-      <p className="text-gray-500">No features implemented yet.</p>
+    <main className="min-h-screen bg-background">
+      <TodoApp />
     </main>
   );
 }

--- a/app/types/todo.ts
+++ b/app/types/todo.ts
@@ -1,0 +1,7 @@
+export interface Todo {
+  id: string;
+  text: string;
+  completed: boolean;
+  dueDate?: string; // ISO date string YYYY-MM-DD
+  createdAt: string;
+}


### PR DESCRIPTION
## Summary
- Add a date picker to set due dates when creating todos
- Allow updating or removing due dates inline on any existing todo
- Display colored status badges: overdue (red), due today (amber), due in ≤3 days (yellow), future (muted)

## Changes
- `app/types/todo.ts` — `Todo` interface with optional `dueDate` (ISO `YYYY-MM-DD`)
- `app/components/DueDateBadge.tsx` — smart badge that calculates relative status
- `app/components/TodoItem.tsx` — todo row with inline date picker and delete
- `app/components/TodoApp.tsx` — full client-side app with localStorage persistence, filters, item count
- `app/page.tsx` — updated to render `TodoApp`

## Test plan
- [ ] Add a todo with a due date set in the past → badge shows red "Overdue"
- [ ] Add a todo due today → badge shows amber "Due today"
- [ ] Add a todo due within 3 days → badge shows yellow "Due in Xd"
- [ ] Add a todo with no due date → no badge shown
- [ ] Click "Add due date" on an existing todo → inline date picker opens
- [ ] Click ✕ next to a date → due date removed
- [ ] Mark todo complete → badge text becomes muted and struck through
- [ ] Filter by all / active / completed works correctly
- [ ] Todos persist after page refresh

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)