### PR TITLE
feat: add Todo type definition and sample data

### DIFF
--- a/app/types.ts
+++ b/app/types.ts
@@ -1,0 +1,27 @@
+export interface Todo {
+  id: string;
+  title: string;
+  completed: boolean;
+  createdAt: string;
+}
+
+export const sampleTodos: Todo[] = [
+  {
+    id: "1",
+    title: "Learn Next.js App Router",
+    completed: true,
+    createdAt: "2026-04-01T09:00:00.000Z",
+  },
+  {
+    id: "2",
+    title: "Build a todo app",
+    completed: false,
+    createdAt: "2026-04-15T12:30:00.000Z",
+  },
+  {
+    id: "3",
+    title: "Write tests",
+    completed: false,
+    createdAt: "2026-04-21T08:15:00.000Z",
+  },
+];


### PR DESCRIPTION
## Summary
- Add `app/types.ts` exporting a `Todo` interface (`id`, `title`, `completed`, `createdAt`) for a shared, typed shape across the app
- Export a `sampleTodos` fixture so upcoming UI work has data to render against without wiring up persistence yet

Closes #136

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)