### PR TITLE
feat: add AddTodo form component

### DIFF
--- a/app/components/AddTodo.tsx
+++ b/app/components/AddTodo.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { useState, type FormEvent } from "react";
+
+type AddTodoProps = {
+  onAdd: (text: string) => void;
+};
+
+export default function AddTodo({ onAdd }: AddTodoProps) {
+  const [text, setText] = useState("");
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const trimmed = text.trim();
+    if (!trimmed) return;
+    onAdd(trimmed);
+    setText("");
+  };
+
+  const isDisabled = text.trim().length === 0;
+
+  return (
+    <form onSubmit={handleSubmit} className="flex gap-2">
+      <label htmlFor="add-todo-input" className="sr-only">
+        Add a new todo
+      </label>
+      <input
+        id="add-todo-input"
+        type="text"
+        value={text}
+        onChange={(event) => setText(event.target.value)}
+        placeholder="What needs to be done?"
+        className="flex-1 rounded-md border border-gray-300 px-3 py-2 text-gray-900 placeholder-gray-400 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
+      />
+      <button
+        type="submit"
+        disabled={isDisabled}
+        className="rounded-md bg-blue-600 px-4 py-2 font-medium text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:bg-gray-300"
+      >
+        Add
+      </button>
+    </form>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds `app/components/AddTodo.tsx` as a client component with a form for adding new todos.
- Calls an `onAdd(text)` callback on submit — the parent owns the todo list state (to be wired up in #140).
- Trims whitespace, blocks empty submissions, and clears the input after a successful add.

## Design notes
- Keeps the component focused and stateless beyond the input value — the `Todo` type and list management belong to the list/page layer, so they're intentionally not defined here.
- Uses a visually hidden `<label>` for accessibility and disables the submit button while the input is empty.
- Styled with Tailwind to match the existing `app/page.tsx` aesthetic.

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [ ] Manual check once parent wiring (#140) lands: typing text + submitting adds a todo and clears the input; empty/whitespace-only submissions are ignored.

Closes #139