### PR TITLE
feat: add Todo type definition and sample data

### DIFF
--- a/app/types.ts
+++ b/app/types.ts
@@ -1,0 +1,27 @@
+export interface Todo {
+  id: string;
+  title: string;
+  completed: boolean;
+  createdAt: Date;
+}
+
+export const sampleTodos: Todo[] = [
+  {
+    id: "1",
+    title: "Learn Next.js App Router",
+    completed: true,
+    createdAt: new Date("2026-04-15T09:00:00Z"),
+  },
+  {
+    id: "2",
+    title: "Build a todo app",
+    completed: false,
+    createdAt: new Date("2026-04-18T10:30:00Z"),
+  },
+  {
+    id: "3",
+    title: "Write tests",
+    completed: false,
+    createdAt: new Date("2026-04-20T14:15:00Z"),
+  },
+];


### PR DESCRIPTION
## Summary
- Adds `app/types.ts` defining a shared `Todo` interface (`id`, `title`, `completed`, `createdAt`)
- Exports `sampleTodos` — a small fixture array so upcoming UI work can render real-looking data before a persistence layer exists

## Why
Upcoming issues (list rendering, add/edit forms, storage) all need a canonical Todo shape. Defining it once here avoids per-component redefinition and keeps the domain model in one place.

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [ ] Reviewer: confirm field set (`id` as string, `createdAt` as Date) is acceptable before downstream work builds on it

Closes #187