### PR TITLE
feat: wire up main page with state management (#200)

### DIFF
--- a/app/components/AddTodo.tsx
+++ b/app/components/AddTodo.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { useState, type FormEvent } from "react";
+
+interface AddTodoProps {
+  onAdd: (text: string) => void;
+}
+
+export function AddTodo({ onAdd }: AddTodoProps) {
+  const [text, setText] = useState("");
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const trimmed = text.trim();
+    if (!trimmed) return;
+    onAdd(trimmed);
+    setText("");
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="flex gap-2">
+      <input
+        type="text"
+        value={text}
+        onChange={(event) => setText(event.target.value)}
+        placeholder="What needs to be done?"
+        className="flex-1 rounded border border-gray-300 px-3 py-2 text-gray-900 focus:border-gray-900 focus:outline-none"
+        aria-label="New todo text"
+      />
+      <button
+        type="submit"
+        disabled={!text.trim()}
+        className="rounded bg-gray-900 px-4 py-2 text-white hover:bg-gray-700 disabled:bg-gray-300"
+      >
+        Add
+      </button>
+    </form>
+  );
+}

--- a/app/components/TodoItem.tsx
+++ b/app/components/TodoItem.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import type { Todo } from "../types";
+
+interface TodoItemProps {
+  todo: Todo;
+  onToggle: (id: string) => void;
+  onDelete: (id: string) => void;
+}
+
+export function TodoItem({ todo, onToggle, onDelete }: TodoItemProps) {
+  return (
+    <li className="flex items-center gap-3 rounded border border-gray-200 bg-white px-4 py-3">
+      <input
+        type="checkbox"
+        checked={todo.completed}
+        onChange={() => onToggle(todo.id)}
+        className="h-4 w-4 cursor-pointer"
+        aria-label={`Mark "${todo.text}" as ${todo.completed ? "incomplete" : "complete"}`}
+      />
+      <span
+        className={`flex-1 text-gray-900 ${
+          todo.completed ? "text-gray-400 line-through" : ""
+        }`}
+      >
+        {todo.text}
+      </span>
+      <button
+        type="button"
+        onClick={() => onDelete(todo.id)}
+        className="rounded px-2 py-1 text-sm text-red-600 hover:bg-red-50"
+        aria-label={`Delete "${todo.text}"`}
+      >
+        Delete
+      </button>
+    </li>
+  );
+}

--- a/app/components/TodoList.tsx
+++ b/app/components/TodoList.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import type { Todo } from "../types";
+import { TodoItem } from "./TodoItem";
+
+interface TodoListProps {
+  todos: Todo[];
+  onToggle: (id: string) => void;
+  onDelete: (id: string) => void;
+}
+
+export function TodoList({ todos, onToggle, onDelete }: TodoListProps) {
+  if (todos.length === 0) {
+    return (
+      <p className="text-gray-500">No todos yet. Add one above to get started.</p>
+    );
+  }
+
+  return (
+    <ul className="flex flex-col gap-2">
+      {todos.map((todo) => (
+        <TodoItem
+          key={todo.id}
+          todo={todo}
+          onToggle={onToggle}
+          onDelete={onDelete}
+        />
+      ))}
+    </ul>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,8 +1,51 @@
+"use client";
+
+import { useState } from "react";
+import { AddTodo } from "./components/AddTodo";
+import { TodoList } from "./components/TodoList";
+import type { Todo } from "./types";
+
+const initialTodos: Todo[] = [
+  { id: "1", text: "Learn Next.js App Router", completed: true },
+  { id: "2", text: "Build a todo app", completed: false },
+];
+
 export default function Home() {
+  const [todos, setTodos] = useState<Todo[]>(initialTodos);
+
+  const addTodo = (text: string) => {
+    setTodos((prev) => [
+      ...prev,
+      { id: crypto.randomUUID(), text, completed: false },
+    ]);
+  };
+
+  const toggleTodo = (id: string) => {
+    setTodos((prev) =>
+      prev.map((todo) =>
+        todo.id === id ? { ...todo, completed: !todo.completed } : todo,
+      ),
+    );
+  };
+
+  const deleteTodo = (id: string) => {
+    setTodos((prev) => prev.filter((todo) => todo.id !== id));
+  };
+
+  const remaining = todos.filter((todo) => !todo.completed).length;
+
   return (
     <main className="min-h-screen bg-white p-8">
-      <h1 className="text-3xl font-bold text-gray-900 mb-2">Todo List</h1>
-      <p className="text-gray-500">No features implemented yet.</p>
+      <div className="mx-auto max-w-2xl">
+        <h1 className="mb-2 text-3xl font-bold text-gray-900">Todo List</h1>
+        <p className="mb-6 text-gray-500">
+          {remaining} of {todos.length} remaining
+        </p>
+        <div className="mb-6">
+          <AddTodo onAdd={addTodo} />
+        </div>
+        <TodoList todos={todos} onToggle={toggleTodo} onDelete={deleteTodo} />
+      </div>
     </main>
   );
 }

--- a/app/types.ts
+++ b/app/types.ts
@@ -1,0 +1,5 @@
+export interface Todo {
+  id: string;
+  text: string;
+  completed: boolean;
+}


### PR DESCRIPTION
## Summary
- Convert `app/page.tsx` to a client component that manages todo state with `useState`
- Add `Todo` type in `app/types.ts` and `AddTodo` / `TodoList` / `TodoItem` components to support the page
- Wire up add, toggle, and delete handlers plus a remaining-count display

Closes #200

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint`
- [ ] Manual: add/toggle/delete todos in the browser