### PR TITLE
feat: add Todo type definition and sample data

### DIFF
--- a/app/types.ts
+++ b/app/types.ts
@@ -1,0 +1,27 @@
+export interface Todo {
+  id: string;
+  title: string;
+  completed: boolean;
+  createdAt: string;
+}
+
+export const sampleTodos: Todo[] = [
+  {
+    id: "1",
+    title: "Learn Next.js App Router",
+    completed: true,
+    createdAt: "2026-05-01T09:00:00.000Z",
+  },
+  {
+    id: "2",
+    title: "Build a todo app",
+    completed: false,
+    createdAt: "2026-05-01T10:30:00.000Z",
+  },
+  {
+    id: "3",
+    title: "Write tests for components",
+    completed: false,
+    createdAt: "2026-05-02T08:15:00.000Z",
+  },
+];


### PR DESCRIPTION
## Summary
- Add `Todo` interface in `app/types.ts` with `id`, `title`, `completed`, and `createdAt` fields
- Export `sampleTodos` seed data so upcoming UI work has typed examples to render against

Closes #266

## Test plan
- [x] `pnpm run typecheck`
- [x] `pnpm run lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)