### PR TITLE
feat: add Daybook field notes blog

### DIFF
--- a/app/blog/[slug]/not-found.tsx
+++ b/app/blog/[slug]/not-found.tsx
@@ -1,0 +1,27 @@
+import Link from "next/link";
+
+export default function PostNotFound() {
+  return (
+    <main
+      id="main-content"
+      className="mx-auto flex min-h-[70vh] w-full max-w-xl flex-col items-center justify-center px-5 py-20 text-center"
+    >
+      <p className="text-xs font-bold tracking-[0.2em] text-[var(--accent-strong)] uppercase">
+        Page missing
+      </p>
+      <h1 className="mt-4 font-serif text-5xl font-semibold text-[var(--ink)]">
+        This note wandered off.
+      </h1>
+      <p className="mt-5 text-base leading-7 text-[var(--muted)]">
+        The field note you requested does not exist, but the rest of the
+        collection is right where you left it.
+      </p>
+      <Link
+        href="/blog"
+        className="mt-8 inline-flex min-h-11 items-center rounded-full bg-[var(--button-bg)] px-5 text-sm font-semibold text-white transition-colors hover:bg-[var(--button-hover)] focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-[var(--accent)]"
+      >
+        Browse field notes
+      </Link>
+    </main>
+  );
+}

--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -1,0 +1,161 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import ArticleGraphic from "@/components/ArticleGraphic";
+import PostContent from "@/components/PostContent";
+import {
+  formatPostDate,
+  getAllPosts,
+  getPostBySlug,
+  getReadingTime,
+} from "@/lib/posts";
+
+interface PostPageProps {
+  params: Promise<{ slug: string }>;
+}
+
+export const dynamicParams = false;
+
+export function generateStaticParams() {
+  return getAllPosts().map((post) => ({ slug: post.slug }));
+}
+
+export async function generateMetadata({
+  params,
+}: PostPageProps): Promise<Metadata> {
+  const { slug } = await params;
+  const post = getPostBySlug(slug);
+
+  if (!post) {
+    return {
+      title: "Note not found",
+      description: "This Daybook field note could not be found.",
+    };
+  }
+
+  return {
+    title: post.title,
+    description: post.description,
+    authors: [{ name: post.author }],
+    openGraph: {
+      type: "article",
+      title: post.title,
+      description: post.description,
+      publishedTime: post.date,
+      authors: [post.author],
+    },
+  };
+}
+
+export default async function PostPage({ params }: PostPageProps) {
+  const { slug } = await params;
+  const post = getPostBySlug(slug);
+
+  if (!post) {
+    notFound();
+  }
+
+  const relatedPosts = getAllPosts()
+    .filter((candidate) => candidate.slug !== post.slug)
+    .slice(0, 2);
+
+  return (
+    <main id="main-content" className="flex-1">
+      <article>
+        <div className="mx-auto w-full max-w-5xl px-5 pb-16 pt-8 sm:px-8 sm:pb-24 sm:pt-12">
+          <nav aria-label="Breadcrumb">
+            <ol className="flex items-center gap-2 text-sm text-[var(--muted)]">
+              <li>
+                <Link
+                  href="/blog"
+                  className="rounded-sm transition-colors hover:text-[var(--accent-strong)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--accent)]"
+                >
+                  Field notes
+                </Link>
+              </li>
+              <li aria-hidden="true" className="text-[var(--line-strong)]">
+                /
+              </li>
+              <li className="truncate" aria-current="page">
+                {post.topic}
+              </li>
+            </ol>
+          </nav>
+
+          <header className="mx-auto max-w-4xl pb-10 pt-12 text-center sm:pb-14 sm:pt-16">
+            <p className="text-xs font-bold tracking-[0.2em] text-[var(--accent-strong)] uppercase">
+              {post.topic}
+            </p>
+            <h1 className="mt-5 font-serif text-4xl font-semibold tracking-[-0.045em] text-balance text-[var(--ink)] sm:text-6xl sm:leading-[1.02]">
+              {post.title}
+            </h1>
+            <p className="mx-auto mt-6 max-w-3xl font-serif text-xl leading-8 text-[var(--muted)] sm:text-2xl sm:leading-9">
+              {post.lead}
+            </p>
+            <div className="mt-8 flex flex-wrap items-center justify-center gap-x-3 gap-y-2 text-sm text-[var(--muted)]">
+              <span>
+                By{" "}
+                <span className="font-semibold text-[var(--ink)]">
+                  {post.author}
+                </span>
+              </span>
+              <span aria-hidden="true" className="text-[var(--line-strong)]">
+                •
+              </span>
+              <time dateTime={post.date}>{formatPostDate(post.date)}</time>
+              <span aria-hidden="true" className="text-[var(--line-strong)]">
+                •
+              </span>
+              <span>{getReadingTime(post)}</span>
+            </div>
+          </header>
+
+          <ArticleGraphic
+            alt="An open daybook in green hills, with a completed task becoming a winding path toward a warm sunrise"
+            priority
+          />
+
+          <div className="mt-16 sm:mt-20">
+            <PostContent post={post} />
+          </div>
+        </div>
+      </article>
+
+      <aside
+        className="border-t border-[var(--line)] bg-[var(--surface)]"
+        aria-labelledby="keep-reading"
+      >
+        <div className="mx-auto w-full max-w-5xl px-5 py-14 sm:px-8 sm:py-20">
+          <p className="text-xs font-bold tracking-[0.16em] text-[var(--muted)] uppercase">
+            More from the collection
+          </p>
+          <h2
+            id="keep-reading"
+            className="mt-2 font-serif text-3xl font-semibold text-[var(--ink)]"
+          >
+            Keep reading
+          </h2>
+          <div className="mt-8 grid gap-5 sm:grid-cols-2">
+            {relatedPosts.map((relatedPost) => (
+              <Link
+                key={relatedPost.slug}
+                href={`/blog/${relatedPost.slug}`}
+                className="group rounded-2xl border border-[var(--line)] bg-[var(--background)] p-6 transition-[border-color,transform,box-shadow] hover:-translate-y-1 hover:border-[var(--line-strong)] hover:shadow-[0_18px_50px_-35px_rgba(26,67,59,0.55)] focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-[var(--accent)]"
+              >
+                <p className="text-xs font-bold tracking-[0.14em] text-[var(--accent-strong)] uppercase">
+                  {relatedPost.topic}
+                </p>
+                <h3 className="mt-3 font-serif text-2xl font-semibold leading-7 text-[var(--ink)] transition-colors group-hover:text-[var(--accent-strong)]">
+                  {relatedPost.title}
+                </h3>
+                <p className="mt-4 text-sm leading-6 text-[var(--muted)]">
+                  {relatedPost.excerpt}
+                </p>
+              </Link>
+            ))}
+          </div>
+        </div>
+      </aside>
+    </main>
+  );
+}

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -1,0 +1,119 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import ArticleGraphic from "@/components/ArticleGraphic";
+import {
+  formatPostDate,
+  getAllPosts,
+  getReadingTime,
+} from "@/lib/posts";
+
+export const metadata: Metadata = {
+  title: "Field Notes",
+  description:
+    "Thoughtful, practical essays from Daybook on AI systems, agents, and the future of building software.",
+};
+
+export default function BlogPage() {
+  const allPosts = getAllPosts();
+
+  return (
+    <main id="main-content" className="flex-1">
+      <section className="border-b border-[var(--line)]">
+        <div className="mx-auto grid w-full max-w-6xl items-center gap-12 px-5 py-14 sm:px-8 sm:py-20 lg:grid-cols-[0.82fr_1.18fr] lg:py-24">
+          <div>
+            <p className="text-xs font-bold tracking-[0.2em] text-[var(--accent-strong)] uppercase">
+              Daybook field notes
+            </p>
+            <h1 className="mt-5 max-w-xl font-serif text-5xl font-semibold tracking-[-0.045em] text-balance text-[var(--ink)] sm:text-6xl lg:text-7xl">
+              Ideas for calmer, more capable work.
+            </h1>
+            <p className="mt-6 max-w-lg text-lg leading-8 text-[var(--muted)]">
+              Carefully researched essays about artificial intelligence,
+              thoughtful systems, and the craft of building tools people can
+              trust.
+            </p>
+          </div>
+          <ArticleGraphic
+            alt="An open daybook in green hills, with a checked task forming a path toward the morning sun"
+            priority
+          />
+        </div>
+      </section>
+
+      <section
+        className="mx-auto w-full max-w-5xl px-5 py-16 sm:px-8 sm:py-24"
+        aria-labelledby="latest-notes"
+      >
+        <div className="flex items-end justify-between gap-6 border-b border-[var(--line)] pb-5">
+          <div>
+            <p className="text-xs font-bold tracking-[0.16em] text-[var(--muted)] uppercase">
+              The collection
+            </p>
+            <h2
+              id="latest-notes"
+              className="mt-2 font-serif text-3xl font-semibold tracking-[-0.025em] text-[var(--ink)] sm:text-4xl"
+            >
+              Latest notes
+            </h2>
+          </div>
+          <p className="hidden text-sm text-[var(--muted)] sm:block">
+            {allPosts.length} essays · updated thoughtfully
+          </p>
+        </div>
+
+        <ol className="divide-y divide-[var(--line)]">
+          {allPosts.map((post, index) => (
+            <li key={post.slug}>
+              <article className="group grid gap-5 py-9 sm:grid-cols-[5rem_1fr] sm:gap-7 sm:py-11">
+                <div className="font-serif text-4xl text-[var(--line-strong)] transition-colors group-hover:text-[var(--warm)]">
+                  {String(index + 1).padStart(2, "0")}
+                </div>
+                <div>
+                  <div className="flex flex-wrap items-center gap-x-3 gap-y-2 text-xs font-semibold tracking-wide text-[var(--muted)] uppercase">
+                    <span className="text-[var(--accent-strong)]">
+                      {post.topic}
+                    </span>
+                    <span aria-hidden="true">/</span>
+                    <time dateTime={post.date}>
+                      {formatPostDate(post.date)}
+                    </time>
+                    <span aria-hidden="true">/</span>
+                    <span>{getReadingTime(post)}</span>
+                  </div>
+
+                  <h3 className="mt-4 max-w-3xl font-serif text-3xl font-semibold tracking-[-0.025em] text-[var(--ink)] sm:text-[2.35rem] sm:leading-[1.08]">
+                    <Link
+                      href={`/blog/${post.slug}`}
+                      className="rounded-sm transition-colors group-hover:text-[var(--accent-strong)] focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-[var(--accent)]"
+                    >
+                      {post.title}
+                    </Link>
+                  </h3>
+                  <p className="mt-4 max-w-3xl text-base leading-7 text-[var(--muted)]">
+                    {post.excerpt}
+                  </p>
+
+                  <div className="mt-5 flex items-center justify-between gap-5">
+                    <p className="text-sm text-[var(--muted)]">
+                      By{" "}
+                      <span className="font-semibold text-[var(--ink)]">
+                        {post.author}
+                      </span>
+                    </p>
+                    <Link
+                      href={`/blog/${post.slug}`}
+                      aria-label={`Read ${post.title}`}
+                      className="inline-flex items-center gap-2 rounded-sm text-sm font-semibold text-[var(--accent-strong)] transition-[gap] group-hover:gap-3 focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-[var(--accent)]"
+                    >
+                      Read note <span aria-hidden="true">→</span>
+                    </Link>
+                  </div>
+                </div>
+              </article>
+            </li>
+          ))}
+        </ol>
+      </section>
+    </main>
+  );
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,26 +1,97 @@
 @import "tailwindcss";
 
 :root {
-  --background: #ffffff;
-  --foreground: #171717;
+  color-scheme: light;
+  --background: #f8f5ed;
+  --foreground: #1b302c;
+  --ink: #1b302c;
+  --article-copy: #344842;
+  --muted: #63726c;
+  --line: #ded9cb;
+  --line-strong: #908f7e;
+  --surface: #fffdf8;
+  --surface-translucent: rgb(248 245 237 / 88%);
+  --surface-strong: #eee9dd;
+  --accent: #4f887b;
+  --accent-strong: #356c61;
+  --accent-deep: #27554d;
+  --button-bg: #356c61;
+  --button-hover: #27554d;
+  --warm: #a55b31;
+  --code-bg: #172824;
+  --code-line: #31453f;
+  --code-copy: #e8f0e9;
+  --code-muted: #a9bcb5;
 }
 
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
   --font-sans: var(--font-geist-sans);
+  --font-serif: var(--font-newsreader);
   --font-mono: var(--font-geist-mono);
 }
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
+    color-scheme: dark;
+    --background: #10201d;
+    --foreground: #eef0e8;
+    --ink: #f2f1e9;
+    --article-copy: #d0d9d2;
+    --muted: #9bada6;
+    --line: #2d403a;
+    --line-strong: #5f776e;
+    --surface: #162824;
+    --surface-translucent: rgb(16 32 29 / 90%);
+    --surface-strong: #213630;
+    --accent: #80b8a9;
+    --accent-strong: #9bc8bb;
+    --accent-deep: #497f73;
+    --button-bg: #497f73;
+    --button-hover: #3f7368;
+    --warm: #e4a777;
+    --code-bg: #0b1614;
+    --code-line: #31453f;
+    --code-copy: #e8f0e9;
+    --code-muted: #a9bcb5;
   }
+}
+
+html {
+  scroll-behavior: smooth;
 }
 
 body {
   background: var(--background);
   color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: var(--font-geist-sans), sans-serif;
+  text-rendering: optimizeLegibility;
+}
+
+h1,
+h2,
+h3 {
+  text-wrap: balance;
+}
+
+p {
+  text-wrap: pretty;
+}
+
+::selection {
+  background: color-mix(in srgb, var(--accent) 30%, transparent);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    transition-duration: 0.01ms !important;
+  }
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import { Geist, Geist_Mono, Newsreader } from "next/font/google";
+import SiteHeader from "@/components/SiteHeader";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -12,9 +13,19 @@ const geistMono = Geist_Mono({
   subsets: ["latin"],
 });
 
+const newsreader = Newsreader({
+  variable: "--font-newsreader",
+  subsets: ["latin"],
+  style: ["normal", "italic"],
+});
+
 export const metadata: Metadata = {
-  title: "Daybook",
-  description: "A simple todo app to track what needs doing today.",
+  title: {
+    default: "Daybook",
+    template: "%s · Daybook",
+  },
+  description:
+    "A calm place to keep track of today—and field notes for thoughtful work.",
 };
 
 export default function RootLayout({
@@ -25,9 +36,24 @@ export default function RootLayout({
   return (
     <html
       lang="en"
-      className={`${geistSans.variable} ${geistMono.variable} h-full antialiased`}
+      className={`${geistSans.variable} ${geistMono.variable} ${newsreader.variable} h-full antialiased`}
     >
-      <body className="min-h-full flex flex-col">{children}</body>
+      <body className="flex min-h-full flex-col">
+        <a
+          href="#main-content"
+          className="fixed left-4 top-3 z-50 -translate-y-20 rounded-full bg-[var(--ink)] px-4 py-2 text-sm font-semibold text-[var(--background)] transition-transform focus:translate-y-0"
+        >
+          Skip to content
+        </a>
+        <SiteHeader />
+        {children}
+        <footer className="mt-auto border-t border-[var(--line)]">
+          <div className="mx-auto flex w-full max-w-6xl flex-col gap-2 px-5 py-7 text-xs leading-5 text-[var(--muted)] sm:flex-row sm:items-center sm:justify-between sm:px-8">
+            <p>Daybook · Make a little room for what matters.</p>
+            <p>Notes for humans working with intelligent tools.</p>
+          </div>
+        </footer>
+      </body>
     </html>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,6 +2,7 @@
 // #108 — Todo deletion  |  #109 — Todo count summary
 "use client";
 
+import Link from "next/link";
 import { useState } from "react";
 import type { Todo } from "@/types/todo";
 import { sampleTodos } from "@/types/todo";
@@ -34,38 +35,66 @@ export default function Home() {
   const activeCount = todos.filter((todo) => !todo.completed).length;
 
   return (
-    <main className="mx-auto min-h-screen w-full max-w-xl px-4 py-10">
-      <header className="mb-6">
-        <h1 className="text-3xl font-bold text-gray-900 dark:text-gray-100">
-          Daybook
+    <main
+      id="main-content"
+      className="mx-auto w-full max-w-2xl flex-1 px-5 py-12 sm:px-8 sm:py-16"
+    >
+      <header className="mb-9 border-b border-[var(--line)] pb-8">
+        <p className="text-xs font-bold tracking-[0.18em] text-[var(--accent-strong)] uppercase">
+          Your day, at a glance
+        </p>
+        <h1 className="mt-3 font-serif text-5xl font-semibold tracking-[-0.04em] text-[var(--ink)] sm:text-6xl">
+          Today&apos;s page
         </h1>
-        <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
-          Keep track of what needs doing today.
+        <p className="mt-4 max-w-md text-base leading-7 text-[var(--muted)]">
+          A quiet list for the things worth carrying forward.
         </p>
       </header>
 
-      <div className="mb-6">
-        <AddTodo onAdd={handleAdd} />
-      </div>
+      <section aria-labelledby="today-list">
+        <h2 id="today-list" className="sr-only">
+          Today&apos;s todo list
+        </h2>
+        <div className="mb-6">
+          <AddTodo onAdd={handleAdd} />
+        </div>
 
-      <TodoList
-        todos={todos}
-        onToggle={handleToggle}
-        onDelete={handleDelete}
-      />
+        <TodoList
+          todos={todos}
+          onToggle={handleToggle}
+          onDelete={handleDelete}
+        />
 
-      <p
-        className="mt-6 text-sm text-gray-500 dark:text-gray-400"
-        aria-live="polite"
-      >
-        {activeCount} active
-        {todos.length > 0 && (
-          <span className="text-gray-400 dark:text-gray-500">
-            {" "}
-            &middot; {todos.length} total
-          </span>
-        )}
-      </p>
+        <p
+          className="mt-6 text-sm text-[var(--muted)]"
+          aria-live="polite"
+        >
+          {activeCount} active
+          {todos.length > 0 && (
+            <span className="text-[var(--muted)]">
+              {" "}
+              &middot; {todos.length} total
+            </span>
+          )}
+        </p>
+      </section>
+
+      <aside className="mt-12 flex items-start justify-between gap-6 rounded-2xl border border-[var(--line)] bg-[var(--surface)] p-5">
+        <div>
+          <p className="text-xs font-bold tracking-[0.14em] text-[var(--warm)] uppercase">
+            Field notes
+          </p>
+          <p className="mt-2 text-sm leading-6 text-[var(--muted)]">
+            Read practical essays on AI, agents, and better developer tools.
+          </p>
+        </div>
+        <Link
+          href="/blog"
+          className="mt-1 shrink-0 rounded-sm text-sm font-semibold text-[var(--accent-strong)] focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-[var(--accent)]"
+        >
+          Explore <span aria-hidden="true">→</span>
+        </Link>
+      </aside>
     </main>
   );
 }

--- a/components/AddTodo.tsx
+++ b/components/AddTodo.tsx
@@ -30,12 +30,12 @@ export default function AddTodo({ onAdd }: AddTodoProps) {
         onChange={(event) => setTitle(event.target.value)}
         placeholder="What needs to be done?"
         autoComplete="off"
-        className="flex-1 rounded-md border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 placeholder:text-gray-400 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
+        className="min-w-0 flex-1 rounded-xl border border-[var(--line-strong)] bg-[var(--surface)] px-4 py-3 text-sm text-[var(--ink)] shadow-sm placeholder:text-[var(--muted)] focus:border-[var(--accent)] focus:outline-none focus:ring-2 focus:ring-[color:var(--accent)]/25"
       />
       <button
         type="submit"
         disabled={title.trim().length === 0}
-        className="rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 dark:focus:ring-offset-gray-900"
+        className="rounded-xl bg-[var(--button-bg)] px-5 py-3 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-[var(--button-hover)] focus:outline-none focus:ring-2 focus:ring-[var(--accent)] focus:ring-offset-2 focus:ring-offset-[var(--background)] disabled:cursor-not-allowed disabled:opacity-50"
       >
         Add
       </button>

--- a/components/ArticleGraphic.tsx
+++ b/components/ArticleGraphic.tsx
@@ -1,0 +1,30 @@
+import Image from "next/image";
+
+interface ArticleGraphicProps {
+  alt: string;
+  priority?: boolean;
+}
+
+export default function ArticleGraphic({
+  alt,
+  priority = false,
+}: ArticleGraphicProps) {
+  return (
+    <figure>
+      <div className="overflow-hidden rounded-[1.75rem] border border-[var(--line)] bg-[var(--surface)] shadow-[0_24px_80px_-42px_rgba(26,67,59,0.55)]">
+        <Image
+          src="/daybook-field-notes.svg"
+          alt={alt}
+          width={1200}
+          height={630}
+          sizes="(max-width: 768px) 100vw, 960px"
+          priority={priority}
+          className="h-auto w-full"
+        />
+      </div>
+      <figcaption className="mt-3 text-center text-xs leading-5 text-[var(--muted)]">
+        A checked intention becomes a path—an original illustration for Daybook.
+      </figcaption>
+    </figure>
+  );
+}

--- a/components/PostContent.tsx
+++ b/components/PostContent.tsx
@@ -1,0 +1,147 @@
+import type { BlogPost, PostBlock } from "@/lib/posts";
+
+function headingId(heading: string): string {
+  return heading
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/(^-|-$)/g, "");
+}
+
+function ContentBlock({ block }: { block: PostBlock }) {
+  if (block.type === "paragraph") {
+    return (
+      <p className="text-[1.0625rem] leading-8 text-[var(--article-copy)]">
+        {block.text}
+      </p>
+    );
+  }
+
+  if (block.type === "quote") {
+    return (
+      <blockquote className="my-10 border-l-2 border-[var(--warm)] pl-6 font-serif text-2xl leading-9 text-[var(--ink)] italic sm:pl-8 sm:text-[1.7rem]">
+        <p>{block.text}</p>
+      </blockquote>
+    );
+  }
+
+  if (block.type === "code") {
+    return (
+      <figure className="my-8 overflow-hidden rounded-2xl border border-[var(--code-line)] bg-[var(--code-bg)] shadow-sm">
+        {block.caption && (
+          <figcaption className="border-b border-[var(--code-line)] px-5 py-3 text-xs font-semibold tracking-wide text-[var(--code-muted)] uppercase">
+            {block.caption}
+          </figcaption>
+        )}
+        <pre className="overflow-x-auto p-5 text-sm leading-7 text-[var(--code-copy)] sm:p-6">
+          <code className="font-mono" data-language={block.language}>
+            {block.code}
+          </code>
+        </pre>
+      </figure>
+    );
+  }
+
+  if (block.ordered) {
+    return (
+      <ol className="my-7 list-decimal space-y-3 pl-6 text-[1.0625rem] leading-8 text-[var(--article-copy)]">
+        {block.items.map((item) => (
+          <li key={item} className="pl-1">
+            {item}
+          </li>
+        ))}
+      </ol>
+    );
+  }
+
+  return (
+    <ul className="my-7 list-disc space-y-3 pl-6 text-[1.0625rem] leading-8 text-[var(--article-copy)] marker:text-[var(--accent)]">
+      {block.items.map((item) => (
+        <li key={item} className="pl-1">
+          {item}
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+export default function PostContent({ post }: { post: BlogPost }) {
+  return (
+    <div className="lg:grid lg:grid-cols-[12rem_minmax(0,42rem)] lg:justify-center lg:gap-12">
+      <aside className="mb-12 border-y border-[var(--line)] py-6 lg:sticky lg:top-8 lg:mb-0 lg:self-start lg:border-y-0 lg:py-1">
+        <h2 className="text-xs font-bold tracking-[0.16em] text-[var(--muted)] uppercase">
+          In this note
+        </h2>
+        <nav className="mt-4" aria-label="Article contents">
+          <ol className="space-y-3 border-l border-[var(--line-strong)] pl-4 text-sm leading-5">
+            {post.sections.map((section) => (
+              <li key={section.heading}>
+                <a
+                  href={`#${headingId(section.heading)}`}
+                  className="text-[var(--muted)] transition-colors hover:text-[var(--accent-strong)] focus-visible:rounded-sm focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--accent)]"
+                >
+                  {section.heading}
+                </a>
+              </li>
+            ))}
+          </ol>
+        </nav>
+      </aside>
+
+      <div>
+        {post.sections.map((section, index) => (
+          <section
+            key={section.heading}
+            aria-labelledby={headingId(section.heading)}
+            className={index === 0 ? "" : "mt-14"}
+          >
+            <h2
+              id={headingId(section.heading)}
+              className="scroll-mt-8 font-serif text-3xl font-semibold tracking-[-0.025em] text-[var(--ink)] sm:text-[2.15rem]"
+            >
+              {section.heading}
+            </h2>
+            <div className="mt-6 space-y-6">
+              {section.blocks.map((block, blockIndex) => (
+                <ContentBlock
+                  key={`${section.heading}-${block.type}-${blockIndex}`}
+                  block={block}
+                />
+              ))}
+            </div>
+          </section>
+        ))}
+
+        <section
+          className="mt-16 border-t border-[var(--line)] pt-8"
+          aria-labelledby="sources-heading"
+        >
+          <h2
+            id="sources-heading"
+            className="font-serif text-2xl font-semibold text-[var(--ink)]"
+          >
+            Sources &amp; further reading
+          </h2>
+          <ul className="mt-5 space-y-3 text-sm leading-6">
+            {post.sources.map((source) => (
+              <li key={source.url} className="flex gap-3">
+                <span
+                  className="mt-2 size-1.5 shrink-0 rounded-full bg-[var(--warm)]"
+                  aria-hidden="true"
+                />
+                <a
+                  href={source.url}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="text-[var(--accent-strong)] underline decoration-[var(--line-strong)] underline-offset-4 transition-colors hover:decoration-[var(--accent-strong)] focus-visible:rounded-sm focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--accent)]"
+                >
+                  {source.label}
+                  <span className="sr-only"> (opens in a new tab)</span>
+                </a>
+              </li>
+            ))}
+          </ul>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/components/SiteHeader.tsx
+++ b/components/SiteHeader.tsx
@@ -1,0 +1,69 @@
+import Link from "next/link";
+
+export default function SiteHeader() {
+  return (
+    <header className="border-b border-[var(--line)] bg-[color:var(--surface-translucent)] backdrop-blur-md">
+      <div className="mx-auto flex h-16 w-full max-w-6xl items-center justify-between px-5 sm:px-8">
+        <Link
+          href="/"
+          className="group inline-flex min-h-11 items-center gap-2.5 rounded-md text-[var(--ink)] focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-[var(--accent)]"
+          aria-label="Daybook home"
+        >
+          <svg
+            viewBox="0 0 32 32"
+            className="size-8"
+            aria-hidden="true"
+          >
+            <path
+              d="M5 9.5c3.7-2 7.4-2 11 .1v17.2c-3.6-2.1-7.3-2.1-11-.1V9.5Z"
+              fill="#fffdf7"
+              stroke="currentColor"
+              strokeWidth="1.4"
+              strokeLinejoin="round"
+            />
+            <path
+              d="M16 9.6c3.6-2.1 7.3-2.1 11-.1v17.2c-3.7-2-7.4-2-11 .1V9.6Z"
+              fill="#f0e8d7"
+              stroke="currentColor"
+              strokeWidth="1.4"
+              strokeLinejoin="round"
+            />
+            <circle cx="23.5" cy="6.5" r="3.5" fill="#eea56e" />
+            <path
+              d="m8.3 17 2.2 2.2 4.1-5"
+              fill="none"
+              stroke="#3d7568"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </svg>
+          <span className="font-serif text-xl font-semibold tracking-[-0.02em]">
+            Daybook
+          </span>
+        </Link>
+
+        <nav aria-label="Primary navigation">
+          <ul className="flex items-center gap-1 text-sm font-medium">
+            <li>
+              <Link
+                href="/"
+                className="inline-flex min-h-11 items-center rounded-full px-3.5 text-[var(--muted)] transition-colors hover:bg-[var(--surface-strong)] hover:text-[var(--ink)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--accent)]"
+              >
+                Today
+              </Link>
+            </li>
+            <li>
+              <Link
+                href="/blog"
+                className="inline-flex min-h-11 items-center rounded-full px-3.5 text-[var(--muted)] transition-colors hover:bg-[var(--surface-strong)] hover:text-[var(--ink)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--accent)]"
+              >
+                Field notes
+              </Link>
+            </li>
+          </ul>
+        </nav>
+      </div>
+    </header>
+  );
+}

--- a/components/TodoItem.tsx
+++ b/components/TodoItem.tsx
@@ -11,22 +11,22 @@ export default function TodoItem({ todo, onToggle, onDelete }: TodoItemProps) {
   const labelId = `todo-label-${todo.id}`;
 
   return (
-    <li className="flex items-center gap-3 rounded-md border border-gray-200 bg-white px-3 py-2 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+    <li className="flex items-center gap-3 rounded-xl border border-[var(--line)] bg-[var(--surface)] px-4 py-3 shadow-sm">
       <input
         id={`todo-${todo.id}`}
         type="checkbox"
         checked={todo.completed}
         onChange={() => onToggle(todo.id)}
         aria-labelledby={labelId}
-        className="h-5 w-5 shrink-0 cursor-pointer rounded border-gray-300 text-blue-600 focus:ring-2 focus:ring-blue-500"
+        className="h-5 w-5 shrink-0 cursor-pointer rounded border-[var(--line-strong)] accent-[var(--accent-strong)] focus:ring-2 focus:ring-[var(--accent)]"
       />
       <label
         id={labelId}
         htmlFor={`todo-${todo.id}`}
         className={`flex-1 cursor-pointer text-sm ${
           todo.completed
-            ? "text-gray-400 line-through dark:text-gray-500"
-            : "text-gray-900 dark:text-gray-100"
+            ? "text-[var(--muted)] line-through"
+            : "text-[var(--ink)]"
         }`}
       >
         {todo.title}
@@ -35,7 +35,7 @@ export default function TodoItem({ todo, onToggle, onDelete }: TodoItemProps) {
         type="button"
         onClick={() => onDelete(todo.id)}
         aria-label={`Delete "${todo.title}"`}
-        className="shrink-0 rounded p-1 text-gray-400 transition-colors hover:text-red-600 focus:outline-none focus:ring-2 focus:ring-red-500 dark:hover:text-red-400"
+        className="inline-flex size-11 shrink-0 items-center justify-center rounded-md text-[var(--muted)] transition-colors hover:text-red-600 focus:outline-none focus:ring-2 focus:ring-red-500"
       >
         <svg
           xmlns="http://www.w3.org/2000/svg"

--- a/components/TodoList.tsx
+++ b/components/TodoList.tsx
@@ -11,7 +11,7 @@ interface TodoListProps {
 export default function TodoList({ todos, onToggle, onDelete }: TodoListProps) {
   if (todos.length === 0) {
     return (
-      <p className="rounded-md border border-dashed border-gray-300 px-3 py-6 text-center text-sm text-gray-500 dark:border-gray-600 dark:text-gray-400">
+      <p className="rounded-xl border border-dashed border-[var(--line-strong)] px-3 py-8 text-center text-sm text-[var(--muted)]">
         No todos yet. Add one above to get started.
       </p>
     );

--- a/lib/posts.ts
+++ b/lib/posts.ts
@@ -1,0 +1,454 @@
+export type PostBlock =
+  | {
+      type: "paragraph";
+      text: string;
+    }
+  | {
+      type: "list";
+      items: string[];
+      ordered?: boolean;
+    }
+  | {
+      type: "code";
+      code: string;
+      language: string;
+      caption?: string;
+    }
+  | {
+      type: "quote";
+      text: string;
+    };
+
+export interface PostSection {
+  heading: string;
+  blocks: PostBlock[];
+}
+
+export interface PostSource {
+  label: string;
+  url: string;
+}
+
+export interface BlogPost {
+  slug: string;
+  title: string;
+  description: string;
+  excerpt: string;
+  date: string;
+  author: string;
+  topic: string;
+  lead: string;
+  sections: PostSection[];
+  sources: PostSource[];
+}
+
+export const posts: BlogPost[] = [
+  {
+    slug: "how-large-language-models-work",
+    title: "How Large Language Models Work, Without the Hand-Waving",
+    description:
+      "A practical tour of tokens, embeddings, attention, training, and generation—and why fluent language models can still be confidently wrong.",
+    excerpt:
+      "From tokens to attention to next-token prediction: a grounded mental model for what an LLM learns, how it produces an answer, and where its limits come from.",
+    date: "2026-07-15",
+    author: "Mira Chen",
+    topic: "Foundations",
+    lead:
+      "An LLM is neither a database with every sentence filed away nor a small person living in a server. It is a learned system for predicting continuations—and that modest description turns out to produce remarkably rich behavior.",
+    sections: [
+      {
+        heading: "Start with the right unit: tokens, not words",
+        blocks: [
+          {
+            type: "paragraph",
+            text: "Before a model sees language, a tokenizer breaks text into a vocabulary of reusable pieces called tokens. A familiar word may be one token; an unusual surname, source-code identifier, or accented phrase may become several. Tokenization matters because the model does not manipulate letters or meanings directly. It receives a sequence of integer token IDs and must learn useful structure from how those IDs occur together.",
+          },
+          {
+            type: "paragraph",
+            text: "Each token ID is mapped to an embedding: a long list of learned numbers. During training, embeddings arrange themselves so that tokens used in related contexts have useful geometric relationships. Position information is added because the same tokens in a different order can mean something entirely different. The result is a sequence of vectors representing both what appeared and where it appeared.",
+          },
+          {
+            type: "quote",
+            text: "The model never receives a dictionary definition of “promise,” “function,” or “kindness.” It learns operational meanings from patterns of use.",
+          },
+        ],
+      },
+      {
+        heading: "Attention builds context on demand",
+        blocks: [
+          {
+            type: "paragraph",
+            text: "The transformer architecture, introduced in the 2017 paper “Attention Is All You Need,” replaced the strictly sequential processing common in earlier language systems with attention. For every token, the model creates a query, key, and value. A query is compared with other tokens’ keys; the resulting scores determine how much of their values should be mixed into the current representation.",
+          },
+          {
+            type: "code",
+            language: "text",
+            caption: "A simplified view of one attention operation",
+            code: "scores  = (query × keysᵀ) / √dimension\nweights = softmax(scores)\ncontext = weights × values",
+          },
+          {
+            type: "paragraph",
+            text: "Different attention heads can learn different relationships. One might connect a pronoun to the noun it refers to; another may track indentation in code; another may notice that a closing quotation mark is expected. A transformer block combines this contextual mixing with a feed-forward network, residual connections, and normalization. Repeating the block many times lets the representation evolve from local spelling and syntax toward more abstract relationships.",
+          },
+          {
+            type: "paragraph",
+            text: "Attention is powerful, but it is not a perfect explanation of the model’s reasoning. Researchers can inspect which tokens influence one another, yet the computation is distributed across many heads and layers. A clean attention map is a clue, not a faithful transcript of an internal thought process.",
+          },
+        ],
+      },
+      {
+        heading: "Training compresses patterns into parameters",
+        blocks: [
+          {
+            type: "paragraph",
+            text: "During pretraining, the model repeatedly receives text with a next token to predict. Its initial guesses are poor. A loss function measures the gap between predicted probabilities and the actual continuation, then backpropagation adjusts billions of parameters by tiny amounts. Repeated across a large and varied corpus, this process rewards parameters that capture reusable regularities: grammar, genre, facts that recur in text, programming idioms, and patterns that resemble step-by-step inference.",
+          },
+          {
+            type: "paragraph",
+            text: "This is better understood as lossy compression than memorization alone. The parameters cannot store a perfect copy of the training set, so the model learns general circuits that help across examples. Memorization can still occur, especially for duplicated or distinctive sequences, but generalization is why a model can write a novel function or explain an analogy it never encountered verbatim.",
+          },
+          {
+            type: "paragraph",
+            text: "Pretraining optimizes continuation, not helpful conversation. Instruction tuning adds examples of desired responses, and preference optimization teaches the model which of several plausible answers people tend to prefer. Tool-use training can teach it to emit structured calls rather than invent an answer. These later stages shape behavior, but the generative engine remains a probability model over tokens.",
+          },
+        ],
+      },
+      {
+        heading: "Generation is a loop, not a retrieved paragraph",
+        blocks: [
+          {
+            type: "paragraph",
+            text: "At inference time, your prompt and conversation history form the context window. The model performs a forward pass and produces a probability distribution for the next token. A decoding strategy selects one token, appends it to the context, and runs the process again. Temperature and sampling settings influence whether selection favors the safest high-probability continuation or explores less likely alternatives.",
+          },
+          {
+            type: "list",
+            items: [
+              "The context window is working memory, not permanent memory. Information outside it must be retrieved or summarized.",
+              "Generation is path-dependent. One early token changes the context for every token that follows.",
+              "The model usually cannot check the external world unless the application gives it search, databases, calculators, or other tools.",
+            ],
+          },
+          {
+            type: "paragraph",
+            text: "This loop explains both fluency and fragility. Every sentence is conditioned on a dense representation of what came before, producing striking coherence. But the objective is still to generate a plausible continuation. When the prompt asks for an obscure citation or an unavailable fact, a plausible-looking invention can score better than an awkward admission of uncertainty.",
+          },
+        ],
+      },
+      {
+        heading: "A useful model of the limits",
+        blocks: [
+          {
+            type: "paragraph",
+            text: "Three distinctions make LLMs easier to use well. First, learned knowledge is not guaranteed knowledge: parameters encode statistical regularities with uneven coverage and uncertain freshness. Second, verbal reasoning is not automatically verified reasoning: a convincing derivation may contain a silent arithmetic or logical error. Third, capability is not agency: a base model returns tokens; an application gives it goals, memory, tools, retries, and permissions.",
+          },
+          {
+            type: "paragraph",
+            text: "Good product design works with those realities. Supply the relevant source material, ask the model to identify uncertainty, use tools for exact calculation and current data, request structured outputs, and verify consequential results. An LLM is most dependable when it is one component in a system with explicit context and checks—not when eloquence is treated as evidence.",
+          },
+        ],
+      },
+    ],
+    sources: [
+      {
+        label: "Attention Is All You Need — Vaswani et al.",
+        url: "https://arxiv.org/abs/1706.03762",
+      },
+      {
+        label: "Training Compute-Optimal Large Language Models — Hoffmann et al.",
+        url: "https://arxiv.org/abs/2203.15556",
+      },
+      {
+        label:
+          "Training language models to follow instructions with human feedback — Ouyang et al.",
+        url: "https://arxiv.org/abs/2203.02155",
+      },
+    ],
+  },
+  {
+    slug: "ai-agents-and-orchestration",
+    title: "AI Agents Need Good Orchestration More Than More Autonomy",
+    description:
+      "A practical architecture guide to agent loops, tools, workflows, orchestration, permissions, observability, and evaluations.",
+    excerpt:
+      "The useful part of an AI agent is not endless autonomy. It is a well-bounded loop, legible tools, purposeful orchestration, and evidence that the work actually succeeded.",
+    date: "2026-07-22",
+    author: "Jon Bell",
+    topic: "Systems",
+    lead:
+      "Calling every multi-step prompt an “agent” hides the engineering decisions that determine whether the system is dependable. The important question is not how human-like it feels, but how it chooses actions, observes results, and stops.",
+    sections: [
+      {
+        heading: "Separate workflows from agents",
+        blocks: [
+          {
+            type: "paragraph",
+            text: "A workflow follows a path chosen in code: classify a request, retrieve a document, draft a response, then run a policy check. An agent lets a model choose at least some of that path dynamically. It may decide which tool to call, inspect the result, revise a plan, and continue until it reaches a stopping condition. Both are useful; neither is inherently more advanced.",
+          },
+          {
+            type: "paragraph",
+            text: "Use a workflow when the task is stable and the acceptable sequence is known. It is easier to test, cheaper to operate, and simpler to explain. Reach for an agent when the path genuinely depends on discoveries made during execution: debugging a repository, investigating an incident, or researching a question whose relevant sources cannot be predicted in advance.",
+          },
+          {
+            type: "quote",
+            text: "Autonomy is a budget to spend where uncertainty demands it, not a feature to maximize.",
+          },
+        ],
+      },
+      {
+        heading: "The agent loop is small; the environment is the product",
+        blocks: [
+          {
+            type: "paragraph",
+            text: "At its center, an agent is a loop. The model receives a goal and current state, chooses an action, the runtime executes that action, and the result returns as a new observation. The loop ends on success, a limit, an error policy, or a request for human input. Production complexity lives around this loop: tool schemas, state storage, retries, credentials, sandboxes, tracing, and user controls.",
+          },
+          {
+            type: "code",
+            language: "ts",
+            caption: "A deliberately simplified agent runtime",
+            code: "for (let turn = 0; turn < maxTurns; turn++) {\n  const decision = await model.next({ goal, state, tools });\n\n  if (decision.type === \"done\") return verify(decision, state);\n  if (!policy.allows(decision.action)) return requestApproval(decision);\n\n  const observation = await execute(decision.action);\n  state = appendTrace(state, decision, observation);\n}\n\nreturn { status: \"limit_reached\", trace: state.trace };",
+          },
+          {
+            type: "paragraph",
+            text: "Tool design deserves the same care as a public API. Names should describe outcomes, parameters should be typed and narrow, error messages should say what can be corrected, and returned data should omit irrelevant noise. A vague “run anything” tool creates a larger decision space and a larger security boundary. Several small tools often make intended actions easier for the model—and for a human reviewer—to understand.",
+          },
+        ],
+      },
+      {
+        heading: "Choose an orchestration pattern deliberately",
+        blocks: [
+          {
+            type: "paragraph",
+            text: "Orchestration coordinates model calls and tools. Prompt chaining works when one stage naturally produces input for the next. Routing sends distinct requests to specialized prompts, models, or policies. Parallelization reduces latency for independent work or gathers several perspectives. An evaluator-optimizer loop drafts, critiques against an explicit rubric, and revises. An orchestrator-worker pattern lets a coordinator discover subtasks and delegate them.",
+          },
+          {
+            type: "list",
+            items: [
+              "Chain when order matters and intermediate checks can catch drift early.",
+              "Route when categories have meaningfully different tools, risk, or cost.",
+              "Parallelize only independent work; otherwise coordination overhead erases the gain.",
+              "Add an evaluator when quality criteria can be written clearly and measured.",
+              "Delegate when the task decomposes after inspection, not merely because multiple agents are available.",
+            ],
+          },
+          {
+            type: "paragraph",
+            text: "Multi-agent systems are especially easy to overbuild. Every handoff can lose context, duplicate effort, increase token cost, or create contradictory state. Start with one agent and good tools. Split roles only when specialization, isolation, or parallel execution produces a measurable improvement over the simpler baseline.",
+          },
+        ],
+      },
+      {
+        heading: "Bound context, memory, and authority",
+        blocks: [
+          {
+            type: "paragraph",
+            text: "An agent needs enough context to act, but more is not always better. Long histories bury important constraints and raise cost. Keep an immutable task brief, a compact working summary, structured state for facts and artifacts, and a trace of raw events for debugging. Retrieval should select relevant material rather than paste an entire knowledge base into every turn.",
+          },
+          {
+            type: "paragraph",
+            text: "Authority should be equally explicit. Separate read tools from write tools. Scope credentials to the task. Require approval for irreversible, expensive, external, or high-impact actions. Put file and network operations in a sandbox when possible. Defend tool outputs as untrusted input because a document or webpage can contain instructions designed to redirect the agent.",
+          },
+          {
+            type: "paragraph",
+            text: "A good stopping policy prevents two common failures: declaring victory based on a polished message, and looping long after useful progress has stopped. Define success in observable state—a passing test, a created reservation, a reconciled record—not in the model’s confidence. Set turn, time, and cost budgets, and make escalation a supported outcome rather than a failure.",
+          },
+        ],
+      },
+      {
+        heading: "Evaluate trajectories and outcomes",
+        blocks: [
+          {
+            type: "paragraph",
+            text: "Single-response scoring is insufficient for agents because errors compound across actions. An evaluation should provide a controlled environment, run the task several times, capture the full trajectory, and grade both the final state and important process constraints. Did the record change correctly? Did the agent avoid a forbidden tool? Did it ask for approval? How much time and money did it use?",
+          },
+          {
+            type: "paragraph",
+            text: "Combine deterministic graders such as tests and database assertions with model-based or human review for qualities that resist exact rules. Keep a regression set drawn from real failures. In production, log tool names, sanitized arguments, latency, errors, approvals, model versions, and terminal outcomes. Without traces, teams end up debugging the final sentence while the actual mistake happened six tool calls earlier.",
+          },
+          {
+            type: "paragraph",
+            text: "The best agent architecture is usually visible, interruptible, and a little boring. It gives the model freedom where judgment is useful while conventional software handles permissions, durable state, and verification. That division is not a compromise. It is how probabilistic intelligence becomes a dependable system.",
+          },
+        ],
+      },
+    ],
+    sources: [
+      {
+        label: "Building effective agents — Anthropic",
+        url: "https://www.anthropic.com/engineering/building-effective-agents",
+      },
+      {
+        label: "A practical guide to building AI agents — OpenAI",
+        url: "https://openai.com/business/guides-and-resources/a-practical-guide-to-building-ai-agents/",
+      },
+      {
+        label: "Demystifying evals for AI agents — Anthropic",
+        url: "https://www.anthropic.com/engineering/demystifying-evals-for-ai-agents",
+      },
+    ],
+  },
+  {
+    slug: "practical-future-ai-developer-tooling",
+    title: "The Practical Future of AI Developer Tooling",
+    description:
+      "Why AI coding tools are moving from autocomplete to verified task execution, and what teams should change in their workflows now.",
+    excerpt:
+      "The next generation of developer tools will not merely write more code. It will compress the loop from intent to evidence—while making judgment, review, and system design more important.",
+    date: "2026-07-29",
+    author: "Asha Raman",
+    topic: "Practice",
+    lead:
+      "The durable promise of AI-assisted development is not that typing disappears. It is that more of the journey from a precise intention to a verified change can become navigable, inspectable, and fast.",
+    sections: [
+      {
+        heading: "From completing lines to completing loops",
+        blocks: [
+          {
+            type: "paragraph",
+            text: "Early AI coding tools lived inside the editor and predicted the next few lines. That interaction remains useful because it is immediate and easy to supervise. Newer systems operate over a repository: they search, edit several files, run commands, interpret failures, and prepare a patch. The unit of assistance is shifting from a snippet to a bounded engineering task.",
+          },
+          {
+            type: "paragraph",
+            text: "That shift changes the interface. A strong tool needs a map of the codebase, access to build and test feedback, an understanding of local conventions, and a way to show its plan and evidence. Chat is only one surface. Diffs, terminal logs, citations to files, review comments, checkpoints, and permission prompts are often more important because they expose what changed and why.",
+          },
+          {
+            type: "quote",
+            text: "The winning workflow will optimize for verified outcomes per unit of attention—not tokens generated or lines added.",
+          },
+        ],
+      },
+      {
+        heading: "Productivity evidence is contextual, not contradictory",
+        blocks: [
+          {
+            type: "paragraph",
+            text: "Research results on coding assistants vary because the tasks and users vary. In a controlled GitHub study, developers using Copilot completed a small JavaScript server task substantially faster. A later GitHub experiment reported modest improvements in several code-quality measures for a scoped API exercise. By contrast, a 2025 METR randomized study found that experienced open-source developers working on their own mature repositories took longer with then-current AI tools, even though participants believed they had been faster.",
+          },
+          {
+            type: "paragraph",
+            text: "Those findings can coexist. A greenfield exercise with clear tests is different from modifying a large system full of tacit constraints. Familiar experts may spend more time prompting, waiting, checking plausible mistakes, and restoring context than they save on implementation. Tool capability also changes quickly, so a result is a measurement of a particular workflow at a particular time—not a universal law of software development.",
+          },
+          {
+            type: "paragraph",
+            text: "Teams should therefore measure their own work. Track cycle time, review time, escaped defects, rollback rate, developer satisfaction, and the fraction of generated changes substantially rewritten. Segment by task: migrations, tests, unfamiliar code navigation, boilerplate, debugging, and architectural work have different profiles. A local baseline is more useful than an industry-wide claim about a single productivity percentage.",
+          },
+        ],
+      },
+      {
+        heading: "Repository context becomes infrastructure",
+        blocks: [
+          {
+            type: "paragraph",
+            text: "Coding models perform better when the repository explains itself. Machine-readable commands, focused architecture notes, representative tests, generated API schemas, stable formatting, and clear module boundaries all reduce ambiguity. These investments help humans too. The difference is that an agent encounters missing documentation at machine speed and can repeat the resulting mistake across many files.",
+          },
+          {
+            type: "list",
+            items: [
+              "Keep one authoritative command for each of build, test, lint, and typecheck.",
+              "Document constraints near the code they govern, and keep instructions short enough to remain current.",
+              "Provide fast, deterministic tests so the tool can close its own feedback loop.",
+              "Use typed interfaces and schemas at system boundaries; natural language should not replace enforceable contracts.",
+              "Make generated changes easy to isolate, inspect, and revert.",
+            ],
+          },
+          {
+            type: "paragraph",
+            text: "Retrieval will become more structural. Instead of stuffing arbitrary file chunks into a prompt, tools can combine dependency graphs, symbol references, version history, issue context, runtime traces, and ownership data. The goal is not maximum context. It is the smallest evidence set that explains the change safely.",
+          },
+        ],
+      },
+      {
+        heading: "Verification moves into the center",
+        blocks: [
+          {
+            type: "paragraph",
+            text: "When producing code becomes cheaper, validation becomes the scarce resource. Future tools will generate tests alongside implementations, but a generated test is not independent proof if it repeats the same misunderstanding. Strong workflows mix checks: type systems, linters, unit and integration tests, property tests, security scanning, previews, benchmarks, and human review guided by risk.",
+          },
+          {
+            type: "code",
+            language: "text",
+            caption: "A risk-aware assistance ladder",
+            code: "read and explain  →  draft a diff  →  run local checks\n        →  request review  →  stage a deployment\n        →  monitor evidence  →  expand authority",
+          },
+          {
+            type: "paragraph",
+            text: "Permission should expand with demonstrated reliability and shrink with risk. Reading code is not the same as changing production configuration. Editing an isolated test fixture is not the same as running a database migration. Useful tools make those boundaries visible and preserve a durable record of actions, inputs, outputs, and approvals.",
+          },
+        ],
+      },
+      {
+        heading: "Developers move upstream—and stay accountable",
+        blocks: [
+          {
+            type: "paragraph",
+            text: "As implementation loops accelerate, developers spend a larger share of time framing problems, selecting tradeoffs, defining invariants, and reviewing behavior. Domain knowledge becomes more valuable, not less: someone must recognize when a technically valid patch violates the product, the organization, or the user’s expectations. Recent research on agentic coding has likewise found that stronger domain expertise helps people direct more effective work.",
+          },
+          {
+            type: "paragraph",
+            text: "Junior engineers still need deliberate practice. If every unfamiliar step is delegated, short-term velocity can create long-term fragility. Teams can use AI as a tutor—asking for explanations, alternatives, and review questions—while reserving tasks that build debugging and systems intuition. Senior engineers need new skills too: writing executable acceptance criteria, designing evaluation suites, and reviewing a stream of small machine-produced changes without succumbing to automation bias.",
+          },
+          {
+            type: "paragraph",
+            text: "The practical future is neither a magical one-prompt application nor business as usual with faster autocomplete. It is a layered engineering environment where models propose and navigate, deterministic systems constrain and verify, and people retain responsibility for goals and consequences. Teams that improve their feedback loops now will benefit from better models later without having to rebuild their working culture around every release.",
+          },
+        ],
+      },
+    ],
+    sources: [
+      {
+        label:
+          "Quantifying GitHub Copilot’s impact on developer productivity and happiness — GitHub",
+        url: "https://github.blog/news-insights/research/research-quantifying-github-copilots-impact-on-developer-productivity-and-happiness/",
+      },
+      {
+        label: "Does GitHub Copilot improve code quality? — GitHub",
+        url: "https://github.blog/news-insights/research/does-github-copilot-improve-code-quality-heres-what-the-data-says/",
+      },
+      {
+        label:
+          "Measuring the Impact of Early-2025 AI on Experienced Open-Source Developer Productivity — METR",
+        url: "https://metr.org/blog/2025-07-10-early-2025-ai-experienced-os-dev-study/",
+      },
+      {
+        label: "Agentic coding and persistent returns to expertise — Anthropic",
+        url: "https://www.anthropic.com/research/claude-code-expertise",
+      },
+    ],
+  },
+];
+
+export function getAllPosts(): BlogPost[] {
+  return [...posts].sort((a, b) => b.date.localeCompare(a.date));
+}
+
+export function getPostBySlug(slug: string): BlogPost | undefined {
+  return posts.find((post) => post.slug === slug);
+}
+
+export function getPostWordCount(post: BlogPost): number {
+  const articleText = post.sections
+    .flatMap((section) => [
+      section.heading,
+      ...section.blocks.flatMap((block) => {
+        if (block.type === "list") return block.items;
+        if (block.type === "code") return block.caption ?? "";
+        return block.text;
+      }),
+    ])
+    .join(" ");
+
+  return articleText.match(/\b[\w’'-]+\b/g)?.length ?? 0;
+}
+
+export function getReadingTime(post: BlogPost): string {
+  const minutes = Math.max(1, Math.ceil(getPostWordCount(post) / 210));
+  return `${minutes} min read`;
+}
+
+export function formatPostDate(date: string): string {
+  return new Intl.DateTimeFormat("en-US", {
+    day: "numeric",
+    month: "long",
+    timeZone: "UTC",
+    year: "numeric",
+  }).format(new Date(`${date}T00:00:00Z`));
+}

--- a/public/daybook-field-notes.svg
+++ b/public/daybook-field-notes.svg
@@ -1,0 +1,130 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="1200"
+  height="630"
+  viewBox="0 0 1200 630"
+  fill="none"
+  role="img"
+  aria-labelledby="daybook-title daybook-description"
+>
+  <title id="daybook-title">A quiet day unfolding from an open notebook</title>
+  <desc id="daybook-description">
+    An open daybook rests in a calm landscape while a checked task becomes a
+    winding path toward the morning sun.
+  </desc>
+
+  <defs>
+    <linearGradient id="sky" x1="204" y1="34" x2="1018" y2="617" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#FAF5E8" />
+      <stop offset=".48" stop-color="#DCEBE3" />
+      <stop offset="1" stop-color="#B9D5D2" />
+    </linearGradient>
+    <linearGradient id="sun" x1="867" y1="93" x2="916" y2="225" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#FFD89A" />
+      <stop offset="1" stop-color="#EE9B68" />
+    </linearGradient>
+    <linearGradient id="hill" x1="338" y1="333" x2="978" y2="590" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#98B8A8" />
+      <stop offset="1" stop-color="#315F59" />
+    </linearGradient>
+    <linearGradient id="paper" x1="357" y1="293" x2="770" y2="572" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#FFFDF8" />
+      <stop offset="1" stop-color="#EEE6D4" />
+    </linearGradient>
+    <linearGradient id="page-edge" x1="573" y1="288" x2="604" y2="565" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#E5D9C2" stop-opacity=".2" />
+      <stop offset=".55" stop-color="#AA9677" stop-opacity=".72" />
+      <stop offset="1" stop-color="#F7F0E2" stop-opacity=".15" />
+    </linearGradient>
+    <filter id="shadow" x="256" y="232" width="701" height="391" filterUnits="userSpaceOnUse">
+      <feDropShadow dx="0" dy="18" stdDeviation="18" flood-color="#1E403C" flood-opacity=".18" />
+    </filter>
+    <clipPath id="frame">
+      <rect x="24" y="24" width="1152" height="582" rx="42" />
+    </clipPath>
+  </defs>
+
+  <g clip-path="url(#frame)">
+    <rect x="24" y="24" width="1152" height="582" rx="42" fill="url(#sky)" />
+
+    <path
+      d="M36 450C143 396 228 410 320 449C409 487 466 455 545 408C646 348 732 346 828 404C930 466 1031 441 1176 367V606H24L36 450Z"
+      fill="#BFD4BF"
+    />
+    <path
+      d="M24 512C157 431 252 450 365 509C451 554 543 527 631 470C731 406 817 406 898 460C982 517 1070 501 1176 427V606H24V512Z"
+      fill="url(#hill)"
+    />
+
+    <circle cx="896" cy="153" r="67" fill="url(#sun)" />
+    <circle cx="896" cy="153" r="87" stroke="#FFF7DC" stroke-opacity=".5" stroke-width="2" />
+    <path d="M896 50V24M896 282V257M793 153H766M1026 153H999M824 81L805 62M988 245L969 226M968 80L987 61" stroke="#FFF8E5" stroke-width="5" stroke-linecap="round" opacity=".75" />
+
+    <path d="M113 151C148 120 184 120 218 151C247 177 274 174 310 143" stroke="#FFFDF4" stroke-width="13" stroke-linecap="round" opacity=".75" />
+    <path d="M127 190C155 165 185 165 212 190" stroke="#FFFDF4" stroke-width="8" stroke-linecap="round" opacity=".52" />
+    <path d="M1028 264C1050 244 1072 244 1094 264C1112 281 1131 280 1154 260" stroke="#EAF3EA" stroke-width="9" stroke-linecap="round" opacity=".62" />
+
+    <path
+      d="M625 494C701 433 715 363 754 323C779 298 815 292 844 306C872 319 876 346 861 365C844 388 811 384 799 361"
+      stroke="#F5D7A7"
+      stroke-width="17"
+      stroke-linecap="round"
+    />
+    <path
+      d="M625 494C701 433 715 363 754 323C779 298 815 292 844 306C872 319 876 346 861 365C844 388 811 384 799 361"
+      stroke="#FFF9E9"
+      stroke-width="5"
+      stroke-linecap="round"
+      stroke-dasharray="2 20"
+    />
+
+    <g opacity=".95">
+      <path d="M787 304C770 273 774 247 804 226C817 261 810 287 787 304Z" fill="#6D9480" />
+      <path d="M801 295C828 274 853 276 874 301C844 315 820 309 801 295Z" fill="#4F7A6A" />
+      <path d="M785 306C801 281 818 263 841 246" stroke="#315F59" stroke-width="3" stroke-linecap="round" />
+    </g>
+
+    <g filter="url(#shadow)">
+      <path
+        d="M276 329C372 279 477 276 589 317V570C473 536 371 541 276 585V329Z"
+        fill="url(#paper)"
+        stroke="#D9CCB5"
+        stroke-width="2"
+      />
+      <path
+        d="M589 317C699 273 807 281 916 335V586C807 539 699 535 589 570V317Z"
+        fill="url(#paper)"
+        stroke="#D9CCB5"
+        stroke-width="2"
+      />
+      <path d="M589 319V568" stroke="url(#page-edge)" stroke-width="13" />
+      <path d="M588 323C576 418 577 499 588 566" stroke="#FFFDF8" stroke-width="3" opacity=".8" />
+
+      <path d="M323 377C391 349 462 347 533 365" stroke="#D8CDBA" stroke-width="4" stroke-linecap="round" />
+      <path d="M323 411C391 385 462 384 533 400" stroke="#E2D8C7" stroke-width="3" stroke-linecap="round" />
+      <path d="M323 457C389 435 459 433 526 448" stroke="#E2D8C7" stroke-width="3" stroke-linecap="round" />
+      <path d="M323 503C386 483 449 482 505 492" stroke="#E2D8C7" stroke-width="3" stroke-linecap="round" />
+
+      <circle cx="331" cy="410" r="12" fill="#DDE9DF" stroke="#547866" stroke-width="3" />
+      <path d="M325 410L330 415L339 404" stroke="#315F59" stroke-width="3.5" stroke-linecap="round" stroke-linejoin="round" />
+      <circle cx="331" cy="456" r="12" fill="#FFFDF8" stroke="#A8A08E" stroke-width="3" />
+      <circle cx="331" cy="502" r="12" fill="#FFFDF8" stroke="#A8A08E" stroke-width="3" />
+
+      <path d="M634 374C694 349 764 349 841 376" stroke="#D8CDBA" stroke-width="4" stroke-linecap="round" />
+      <path d="M634 415C697 392 763 393 852 423" stroke="#E2D8C7" stroke-width="3" stroke-linecap="round" />
+      <path d="M634 458C699 438 763 440 828 459" stroke="#E2D8C7" stroke-width="3" stroke-linecap="round" />
+      <path d="M634 500C695 482 750 483 801 496" stroke="#E2D8C7" stroke-width="3" stroke-linecap="round" />
+
+      <path d="M834 516C848 495 865 483 885 478C879 500 864 516 834 516Z" fill="#789C87" />
+      <path d="M832 516C819 494 801 481 781 477C787 500 803 515 832 516Z" fill="#A6BEA4" />
+      <path d="M833 516V542" stroke="#4D7768" stroke-width="4" stroke-linecap="round" />
+    </g>
+
+    <path d="M117 531C155 501 190 498 224 520" stroke="#E7C79B" stroke-width="7" stroke-linecap="round" opacity=".85" />
+    <circle cx="1055" cy="473" r="8" fill="#F6D2A4" />
+    <circle cx="1090" cy="504" r="5" fill="#F6D2A4" opacity=".72" />
+    <circle cx="1019" cy="514" r="4" fill="#F6D2A4" opacity=".6" />
+  </g>
+
+  <rect x="24" y="24" width="1152" height="582" rx="42" stroke="#315F59" stroke-opacity=".16" stroke-width="2" />
+</svg>


### PR DESCRIPTION
## Summary

- Adds an original 1200×630 Daybook illustration built by hand from SVG paths, with a warm sunrise, layered moss hills, an open notebook, and a checked task that becomes a winding path. The asset includes embedded title and description elements and is reused as the blog hero and every article header.
- Adds a responsive, accessible Field Notes index and statically generated dynamic article pages, plus a shared site header with navigation from the main Daybook page.
- Refreshes the existing todo UI with the same calm paper, ink, moss, and amber design tokens so the app and editorial experience feel cohesive in light and dark color schemes.

## Blog architecture

- Uses a typed structured-content model in lib/posts.ts with discriminated paragraph, list, quote, and code blocks.
- Centralizes post lookup, reverse-chronological sorting, date formatting, word counts, and computed reading time.
- Uses generateStaticParams for all post slugs and generateMetadata for per-article title, description, author, publication date, and Open Graph article data.
- Provides semantic articles, landmarks, heading structure, a table of contents, descriptive image alternatives, keyboard-visible focus states, a skip link, responsive code blocks, sources, related posts, and a custom not-found state.

## Posts added

1. How Large Language Models Work, Without the Hand-Waving — 780 words on tokens, embeddings, attention, training, inference, and limitations.
2. AI Agents Need Good Orchestration More Than More Autonomy — 742 words on agent loops, tools, orchestration patterns, permissions, observability, and evaluations.
3. The Practical Future of AI Developer Tooling — 763 words on repository-scale agents, mixed productivity evidence, context infrastructure, verification, and changing developer responsibilities.

Each article links to primary research or first-party technical sources for further reading.

## Verification

- pnpm install
- pnpm typecheck
- pnpm lint
- pnpm build
- Browser smoke tests at desktop and 390px mobile widths for navigation, static metadata, heading and landmark structure, image alternatives, horizontal overflow, source links, keyboard focus, and todo add/toggle/delete behavior
- SVG XML validation and git diff whitespace validation